### PR TITLE
Remove primary labeling for HA deployments

### DIFF
--- a/playbooks/ha/post_install.yml
+++ b/playbooks/ha/post_install.yml
@@ -40,13 +40,9 @@
 
     - pause: seconds=5
 
-    - name: Label master on the infra region
+    - name: Label infrastructure nodes on the infra region
       command: oc label node {{item}} region=infra --overwrite
       with_items: "{{ groups['infra_nodes'] }}"
-
-    - name: Label worker nodes on the primary region
-      command: oc label node {{item}} region=primary --overwrite
-      with_items: "{{ groups['nodes'] }}"
 
     - name: Create default router
       command: "oadm router --create=true \


### PR DESCRIPTION
For HA deployments not all nodes are "primary" and by default all worker nodes are schedulable and do not need a "primary" label to schedule pods.